### PR TITLE
Widget usage logging + contacts, desktop-only mobile gate, OBS setup modal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@
 LFM_API_KEY=
 LFM_SHARED_SECRET=
 REDIS_URL=redis://localhost:6379
+# Optional: Postgres for the widget usage log (which Last.fm usernames open/copy
+# the overlay). Unset = logging is disabled and the endpoint no-ops (fails open).
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/applem
 PORT=8787
 LOG_LEVEL=info
 

--- a/apps/server/drizzle/0000_concerned_monster_badoon.sql
+++ b/apps/server/drizzle/0000_concerned_monster_badoon.sql
@@ -1,0 +1,34 @@
+CREATE TABLE "contacts" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "contacts_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"email" text NOT NULL,
+	"lfm_user" text,
+	"fingerprint" text,
+	"ip" text,
+	"user_agent" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "contacts_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "widget_events" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "widget_events_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"event" text NOT NULL,
+	"lfm_user" text NOT NULL,
+	"fingerprint" text DEFAULT '' NOT NULL,
+	"track_name" text,
+	"track_artist" text,
+	"track_album" text,
+	"is_playing" boolean,
+	"ip" text,
+	"user_agent" text,
+	"referer" text,
+	"seen_count" integer DEFAULT 1 NOT NULL,
+	"first_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_seen_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "contacts_lfm_user_idx" ON "contacts" USING btree ("lfm_user");--> statement-breakpoint
+CREATE INDEX "contacts_fingerprint_idx" ON "contacts" USING btree ("fingerprint");--> statement-breakpoint
+CREATE UNIQUE INDEX "widget_events_identity_idx" ON "widget_events" USING btree ("lfm_user","fingerprint","event");--> statement-breakpoint
+CREATE INDEX "widget_events_lfm_user_idx" ON "widget_events" USING btree ("lfm_user");--> statement-breakpoint
+CREATE INDEX "widget_events_last_seen_idx" ON "widget_events" USING btree ("last_seen_at");

--- a/apps/server/drizzle/meta/0000_snapshot.json
+++ b/apps/server/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,302 @@
+{
+  "id": "33164af2-a347-4d6f-a1ad-ad322392b4a4",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "contacts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lfm_user": {
+          "name": "lfm_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contacts_lfm_user_idx": {
+          "name": "contacts_lfm_user_idx",
+          "columns": [
+            {
+              "expression": "lfm_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_fingerprint_idx": {
+          "name": "contacts_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contacts_email_unique": {
+          "name": "contacts_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget_events": {
+      "name": "widget_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "widget_events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lfm_user": {
+          "name": "lfm_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_artist": {
+          "name": "track_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_album": {
+          "name": "track_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_playing": {
+          "name": "is_playing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referer": {
+          "name": "referer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_count": {
+          "name": "seen_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "widget_events_identity_idx": {
+          "name": "widget_events_identity_idx",
+          "columns": [
+            {
+              "expression": "lfm_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "widget_events_lfm_user_idx": {
+          "name": "widget_events_lfm_user_idx",
+          "columns": [
+            {
+              "expression": "lfm_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "widget_events_last_seen_idx": {
+          "name": "widget_events_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1780462658962,
+      "tag": "0000_concerned_monster_badoon",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "drizzle-orm": "^0.45.2",
     "hono": "^4.6.14"
   },
   "devDependencies": {

--- a/apps/server/src/analytics.ts
+++ b/apps/server/src/analytics.ts
@@ -1,0 +1,116 @@
+import type { Context } from "hono";
+import type { AppEnv } from "./types";
+import { clientIp, rateLimit } from "./security";
+import { dbEnabled, logWidgetEvent, upsertContact, type WidgetEvent } from "./db";
+import { json } from "./util";
+
+// Caps on incoming string lengths — these endpoints are unauthenticated, so
+// treat the body as untrusted and never store unbounded values.
+const MAX_USER = 64;
+const MAX_FP = 128;
+const MAX_TEXT = 256;
+const MAX_EMAIL = 254; // RFC 5321 maximum
+
+function clip(value: unknown, max: number): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.length > max ? trimmed.slice(0, max) : trimmed;
+}
+
+// Pragmatic email check (not a full RFC parser): one @, a dot in the domain, no
+// whitespace. Good enough to reject junk before storing.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type Meta = { ip: string | null; userAgent: string | null; referer: string | null };
+
+/**
+ * Turn an untrusted request body + server-derived metadata into a sanitized
+ * WidgetEvent. Pure (no I/O) so it's unit-testable. Defaults the event to
+ * "open" and only ever records "open" or "copy".
+ */
+export function buildWidgetEvent(body: unknown, meta: Meta): WidgetEvent {
+  const b = (body ?? {}) as Record<string, unknown>;
+  const track = (b.track ?? {}) as Record<string, unknown>;
+  const isPlaying =
+    typeof b.isPlaying === "boolean" ? b.isPlaying : typeof track.isPlaying === "boolean" ? track.isPlaying : null;
+
+  return {
+    event: b.event === "copy" ? "copy" : "open",
+    lfmUser: clip(b.lfmUser, MAX_USER) ?? "",
+    fingerprint: clip(b.fp, MAX_FP),
+    trackName: clip(track.name, MAX_TEXT),
+    trackArtist: clip(track.artist, MAX_TEXT),
+    trackAlbum: clip(track.album, MAX_TEXT),
+    isPlaying,
+    ip: clip(meta.ip, MAX_USER),
+    userAgent: clip(meta.userAgent, MAX_TEXT),
+    referer: clip(meta.referer, MAX_TEXT),
+  };
+}
+
+/**
+ * POST /api/log/widget — records a widget open/copy. Always answers 204 and
+ * SILENTLY: malformed bodies, rate-limited callers, and DB errors all return 204
+ * so opening/copying the widget is never blocked. Deduped + sanitized downstream.
+ */
+export const handleWidgetLog = async (c: Context<AppEnv>) => {
+  const noContent = new Response(null, { status: 204 });
+  if (!dbEnabled()) return noContent;
+
+  // Dedicated, tighter limit for this endpoint (on top of the global /api one).
+  // Silently drop when exceeded — the client never sees an error.
+  if (!(await rateLimit("log", clientIp(c), 30, 60))) return noContent;
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return noContent;
+  }
+
+  const event = buildWidgetEvent(body, {
+    ip: clientIp(c),
+    userAgent: c.req.header("user-agent") ?? null,
+    referer: c.req.header("referer") ?? null,
+  });
+
+  // Only usernames are interesting — skip anonymous pings.
+  if (event.lfmUser) void logWidgetEvent(event);
+
+  return noContent;
+};
+
+/**
+ * POST /api/contact — saves a contact email (upserted, linked to a Last.fm
+ * username). Unlike the log endpoint this has a form UI, so it returns real
+ * status codes: 200 ok, 400 invalid email, 429 too many, 503 when logging is off.
+ */
+export const handleContact = async (c: Context<AppEnv>) => {
+  if (!dbEnabled()) return json({ ok: false, error: "Contact storage is not configured." }, { status: 503 });
+
+  if (!(await rateLimit("contact", clientIp(c), 5, 600))) {
+    return json({ ok: false, error: "Too many submissions — try again later." }, { status: 429 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await c.req.json()) as Record<string, unknown>;
+  } catch {
+    return json({ ok: false, error: "Invalid request." }, { status: 400 });
+  }
+
+  const email = clip(body.email, MAX_EMAIL)?.toLowerCase() ?? "";
+  if (!EMAIL_RE.test(email)) return json({ ok: false, error: "Enter a valid email address." }, { status: 400 });
+
+  const ok = await upsertContact({
+    email,
+    lfmUser: clip(body.lfmUser, MAX_USER),
+    fingerprint: clip(body.fp, MAX_FP),
+    ip: clip(clientIp(c), MAX_USER),
+    userAgent: clip(c.req.header("user-agent"), MAX_TEXT),
+  });
+
+  if (!ok) return json({ ok: false, error: "Couldn't save right now — try again later." }, { status: 503 });
+  return json({ ok: true });
+};

--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -1,0 +1,201 @@
+import { drizzle, type BunSQLDatabase } from "drizzle-orm/bun-sql";
+import { migrate } from "drizzle-orm/bun-sql/migrator";
+import { and, desc, eq, isNotNull, sql } from "drizzle-orm";
+import { fileURLToPath } from "node:url";
+import { contacts, widgetEvents } from "./schema";
+import { log } from "./log";
+
+// Postgres via Drizzle ORM (on Bun's native SQL client). Backs the optional
+// widget usage log + contact emails. Modeled on redis.ts: FAILS OPEN — a missing
+// or unreachable database is logged and ignored, never blocking a request.
+
+const DB_TIMEOUT_MS = 4000;
+const MIGRATE_TIMEOUT_MS = 15000;
+const MIGRATIONS_DIR = fileURLToPath(new URL("../drizzle", import.meta.url));
+
+let db: BunSQLDatabase | null = null;
+// Memoized "migrations applied" promise so we run them at most once per process.
+// Reset to null on failure so the next write retries.
+let migrated: Promise<void> | null = null;
+
+export function dbEnabled() {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+function getDb(): BunSQLDatabase | null {
+  if (!dbEnabled()) return null;
+  if (!db) db = drizzle(process.env.DATABASE_URL!);
+  return db;
+}
+
+function withTimeout<T>(run: () => Promise<T>, label: string, ms = DB_TIMEOUT_MS): Promise<T> {
+  // Drizzle query builders are LAZY thenables — they re-run the SQL on every
+  // `.then()`. Adopt the query as a real native promise (executed exactly once)
+  // before we attach `.catch` and race it, so it can't fire twice.
+  const promise = (async () => await run())();
+  promise.catch(() => {}); // a late rejection must never go unhandled
+
+  let timer: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
+async function ensureMigrated(d: BunSQLDatabase): Promise<void> {
+  if (!migrated) {
+    migrated = withTimeout(() => migrate(d, { migrationsFolder: MIGRATIONS_DIR }), "migrate", MIGRATE_TIMEOUT_MS).catch(
+      (err) => {
+        migrated = null; // allow a retry on the next write
+        throw err;
+      },
+    );
+  }
+  await migrated;
+}
+
+export type WidgetEvent = {
+  event: string; // "open" | "copy"
+  lfmUser: string; // always present — anonymous events are dropped before here
+  fingerprint: string | null;
+  trackName: string | null;
+  trackArtist: string | null;
+  trackAlbum: string | null;
+  isPlaying: boolean | null;
+  ip: string | null;
+  userAgent: string | null;
+  referer: string | null;
+};
+
+/**
+ * Record a usage event. Deduplicated: one row per (lfm_user, fingerprint, event)
+ * — a repeat open/copy from the same device bumps seen_count + last_seen_at and
+ * refreshes the latest song instead of inserting a duplicate. Best-effort
+ * (returns false, never throws).
+ */
+export async function logWidgetEvent(e: WidgetEvent): Promise<boolean> {
+  const d = getDb();
+  if (!d) return false;
+
+  try {
+    await ensureMigrated(d);
+
+    await withTimeout(
+      () =>
+        d
+          .insert(widgetEvents)
+          .values({
+            event: e.event,
+            lfmUser: e.lfmUser,
+            fingerprint: e.fingerprint ?? "",
+            trackName: e.trackName,
+            trackArtist: e.trackArtist,
+            trackAlbum: e.trackAlbum,
+            isPlaying: e.isPlaying,
+            ip: e.ip,
+            userAgent: e.userAgent,
+            referer: e.referer,
+          })
+          .onConflictDoUpdate({
+            target: [widgetEvents.lfmUser, widgetEvents.fingerprint, widgetEvents.event],
+            set: {
+              seenCount: sql`${widgetEvents.seenCount} + 1`,
+              lastSeenAt: sql`now()`,
+              trackName: e.trackName,
+              trackArtist: e.trackArtist,
+              trackAlbum: e.trackAlbum,
+              isPlaying: e.isPlaying,
+              ip: e.ip,
+              userAgent: e.userAgent,
+              referer: e.referer,
+            },
+          }),
+      "widget upsert",
+    );
+    return true;
+  } catch (err) {
+    // Re-run migrations on the next write — self-heals if the schema went missing
+    // (e.g. the database was wiped/recreated under a long-lived server).
+    migrated = null;
+    log("warn", "db.widget_event_failed", { error: err instanceof Error ? err.message : String(err) });
+    return false;
+  }
+}
+
+export type ContactInput = {
+  email: string;
+  lfmUser: string | null;
+  fingerprint: string | null;
+  ip: string | null;
+  userAgent: string | null;
+};
+
+/**
+ * Save a contact email (upserted by email — no duplicates). Links it to a
+ * Last.fm username: uses the one submitted with the form, or, when absent,
+ * recovers it from the usage log by matching the same device fingerprint. On
+ * conflict, only fills in fields we now know — never clobbers a known username
+ * with null.
+ */
+export async function upsertContact(c: ContactInput): Promise<boolean> {
+  const d = getDb();
+  if (!d) return false;
+
+  try {
+    await ensureMigrated(d);
+
+    let lfmUser = c.lfmUser;
+    if (!lfmUser && c.fingerprint) {
+      const found = await withTimeout(
+        () =>
+          d
+            .select({ u: widgetEvents.lfmUser })
+            .from(widgetEvents)
+            .where(and(eq(widgetEvents.fingerprint, c.fingerprint!), isNotNull(widgetEvents.lfmUser)))
+            .orderBy(desc(widgetEvents.lastSeenAt))
+            .limit(1),
+        "contact link",
+      );
+      lfmUser = found[0]?.u ?? null;
+    }
+
+    await withTimeout(
+      () =>
+        d
+          .insert(contacts)
+          .values({
+            email: c.email,
+            lfmUser,
+            fingerprint: c.fingerprint,
+            ip: c.ip,
+            userAgent: c.userAgent,
+          })
+          .onConflictDoUpdate({
+            target: contacts.email,
+            set: {
+              // coalesce(new, existing) keeps a known value rather than nulling it.
+              lfmUser: sql`coalesce(${lfmUser}, ${contacts.lfmUser})`,
+              fingerprint: sql`coalesce(${c.fingerprint}, ${contacts.fingerprint})`,
+              ip: sql`coalesce(${c.ip}, ${contacts.ip})`,
+              userAgent: sql`coalesce(${c.userAgent}, ${contacts.userAgent})`,
+              updatedAt: sql`now()`,
+            },
+          }),
+      "contact upsert",
+    );
+    return true;
+  } catch (err) {
+    migrated = null; // self-heal a missing schema on the next write
+    log("warn", "db.contact_failed", { error: err instanceof Error ? err.message : String(err) });
+    return false;
+  }
+}
+
+export async function dbPing(): Promise<boolean> {
+  const d = getDb();
+  if (!d) return false;
+  const rows = (await withTimeout(() => d.execute(sql`select 1 as ok`), "ping")) as Array<{ ok: number }>;
+  return rows?.[0]?.ok === 1;
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -3,7 +3,9 @@ import { join, normalize } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AppEnv } from "./types";
 import { handleProxyImage, handleRecent, handleSession, handleTrackInfo } from "./lastfm";
+import { handleContact, handleWidgetLog } from "./analytics";
 import { redisEnabled, redisPing } from "./redis";
+import { dbEnabled, dbPing } from "./db";
 import { clientIp, rateLimitOk } from "./security";
 import { json, xmlEscape } from "./util";
 import { log } from "./log";
@@ -65,16 +67,28 @@ app.options("/api/*", () => new Response(null, { status: 204 }));
 app.get("/api/ping", () => json({ ok: true }));
 
 app.get("/api/health", async () => {
-  if (!redisEnabled()) return json({ ok: true, redis: "disabled" });
+  // Postgres backs only the optional usage log, so its status is informational
+  // and never changes the response code.
+  let db = "disabled";
+  if (dbEnabled()) {
+    try {
+      db = (await dbPing()) ? "connected" : "unhealthy";
+    } catch {
+      db = "error";
+    }
+  }
+
+  if (!redisEnabled()) return json({ ok: true, redis: "disabled", db });
 
   try {
     const ok = await redisPing();
-    return json({ ok: true, redis: ok ? "connected" : "unhealthy" }, { status: ok ? 200 : 503 });
+    return json({ ok: true, redis: ok ? "connected" : "unhealthy", db }, { status: ok ? 200 : 503 });
   } catch (error) {
     return json(
       {
         ok: false,
         redis: "error",
+        db,
         error: error instanceof Error ? error.message : String(error),
       },
       { status: 503 },
@@ -86,6 +100,8 @@ app.get("/api/lastfm/recent", handleRecent);
 app.get("/api/lastfm/trackInfo", handleTrackInfo);
 app.post("/api/lastfm/session", handleSession);
 app.get("/api/proxy-image", handleProxyImage);
+app.post("/api/log/widget", handleWidgetLog);
+app.post("/api/contact", handleContact);
 
 app.all("/api/*", () => json({ error: "Not found" }, { status: 404 }));
 
@@ -169,6 +185,7 @@ const port = Number(process.env.PORT) || 8787;
 log("info", "server.start", {
   port,
   redis: redisEnabled() ? "configured" : "disabled",
+  db: dbEnabled() ? "configured" : "disabled",
   webDir: WEB_DIR,
 });
 

--- a/apps/server/src/schema.ts
+++ b/apps/server/src/schema.ts
@@ -1,0 +1,56 @@
+import { bigint, boolean, index, integer, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+
+/**
+ * Widget usage log. One row per unique (lfm_user, fingerprint, event) so repeated
+ * opens/copies from the same device DON'T create duplicate rows — the upsert in
+ * db.ts bumps `seen_count` / `last_seen_at` and refreshes the latest song instead.
+ */
+export const widgetEvents = pgTable(
+  "widget_events",
+  {
+    id: bigint("id", { mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
+    event: text("event").notNull(), // "open" | "copy"
+    lfmUser: text("lfm_user").notNull(),
+    // Empty string (not null) when unknown, so the unique index treats it as one bucket.
+    fingerprint: text("fingerprint").notNull().default(""),
+    trackName: text("track_name"),
+    trackArtist: text("track_artist"),
+    trackAlbum: text("track_album"),
+    isPlaying: boolean("is_playing"),
+    ip: text("ip"),
+    userAgent: text("user_agent"),
+    referer: text("referer"),
+    seenCount: integer("seen_count").notNull().default(1),
+    firstSeenAt: timestamp("first_seen_at", { withTimezone: true }).notNull().defaultNow(),
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex("widget_events_identity_idx").on(t.lfmUser, t.fingerprint, t.event),
+    index("widget_events_lfm_user_idx").on(t.lfmUser),
+    index("widget_events_last_seen_idx").on(t.lastSeenAt),
+  ],
+);
+
+/**
+ * Contact emails captured from the editor's "Contact" form. Linked back to a
+ * Last.fm username (either supplied with the email, or recovered from the usage
+ * log by matching the same device fingerprint) so an outage email can name the
+ * user's widget. Upserted by email — one row per address.
+ */
+export const contacts = pgTable(
+  "contacts",
+  {
+    id: bigint("id", { mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
+    email: text("email").notNull().unique(),
+    lfmUser: text("lfm_user"),
+    fingerprint: text("fingerprint"),
+    ip: text("ip"),
+    userAgent: text("user_agent"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [index("contacts_lfm_user_idx").on(t.lfmUser), index("contacts_fingerprint_idx").on(t.fingerprint)],
+);
+
+export type WidgetEventRow = typeof widgetEvents.$inferInsert;
+export type ContactRow = typeof contacts.$inferInsert;

--- a/apps/server/src/security.ts
+++ b/apps/server/src/security.ts
@@ -33,6 +33,24 @@ export async function rateLimitOk(ip: string, reqId: string): Promise<{ ok: bool
   }
 }
 
+/**
+ * Generic fixed-window limiter for a single named action (e.g. usage logging or
+ * the contact form), separate from the global per-IP limit above. `bucket`
+ * scopes the counter (typically a client IP). Fails OPEN when Redis is down.
+ */
+export async function rateLimit(action: string, bucketId: string, max: number, windowSeconds: number): Promise<boolean> {
+  if (!redisEnabled()) return true;
+  try {
+    const window = Math.floor(Date.now() / 1000 / windowSeconds);
+    const key = `rl:${action}:${bucketId}:${window}`;
+    const count = await redisIncr(key);
+    if (count === 1) await redisExpire(key, windowSeconds);
+    return count <= max;
+  } catch {
+    return true; // fail open
+  }
+}
+
 // --- Image proxy host allowlist ------------------------------------------
 // The image proxy must only fetch known album-art CDNs, otherwise it becomes an
 // open proxy / SSRF vector (fetching internal hosts, arbitrary sites, etc.).

--- a/apps/web/src/lib/MobileGate.svelte
+++ b/apps/web/src/lib/MobileGate.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { submitContact, isValidEmail, type ContactResult } from "$lib/usage";
+
+  const repo = "https://github.com/oyuh/applem-util";
+  const personalSite = "https://github.com/oyuh";
+
+  let email = $state("");
+  let sending = $state(false);
+  let result = $state<ContactResult | null>(null);
+  const canSend = $derived(isValidEmail(email) && !sending);
+
+  const resultMsg: Record<ContactResult, string> = {
+    ok: "Got it — we'll email you. See you on desktop!",
+    invalid: "Enter a valid email address.",
+    rate: "Too many tries — give it a few minutes.",
+    error: "Couldn't save — try again later.",
+  };
+
+  async function send() {
+    if (!canSend) return;
+    sending = true;
+    result = null;
+    result = await submitContact(email, "");
+    sending = false;
+    if (result === "ok") email = "";
+  }
+</script>
+
+<div class="flex min-h-[100dvh] flex-col items-center justify-center gap-6 bg-background px-6 py-12 text-foreground">
+  <div class="w-full max-w-sm rounded-2xl border border-border bg-card p-6 text-card-foreground shadow-xl">
+    <div class="font-pixel text-xs tracking-wide text-muted-foreground uppercase">fast.Jamlog.lol</div>
+    <h1 class="mt-2 text-xl font-semibold tracking-tight">Desktop only — for now</h1>
+    <p class="mt-2 text-sm leading-relaxed text-muted-foreground">
+      The widget editor needs a mouse and a wider screen, so it only works on a computer. Drop your email
+      and we'll remind you to set it up when you're back at your desk (we'll only email about that and outages).
+    </p>
+
+    <div class="mt-4 flex flex-col gap-2">
+      <div class="flex gap-2">
+        <input
+          type="email"
+          bind:value={email}
+          onkeydown={(e) => e.key === "Enter" && send()}
+          placeholder="you@email.com"
+          autocomplete="email"
+          spellcheck="false"
+          class="min-w-0 flex-1 rounded-md border border-border bg-zinc-800 px-3 py-2 text-sm text-foreground"
+        />
+        <button
+          type="button"
+          onclick={send}
+          disabled={!canSend}
+          class="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-40"
+        >
+          {sending ? "…" : "Email me"}
+        </button>
+      </div>
+      {#if result}
+        <p class="text-xs {result === 'ok' ? 'text-green-400' : 'text-amber-500'}">{resultMsg[result]}</p>
+      {/if}
+    </div>
+
+    <div class="mt-5 flex items-center gap-4 border-t border-border pt-4 text-sm">
+      <a href={repo} target="_blank" rel="noopener noreferrer" class="text-muted-foreground hover:text-foreground">
+        View source ↗
+      </a>
+      <a href={personalSite} target="_blank" rel="noopener noreferrer" class="text-muted-foreground hover:text-foreground">
+        My site ↗
+      </a>
+    </div>
+  </div>
+
+  <p class="font-pixel text-[11px] text-muted-foreground">Last.fm now-playing overlay</p>
+</div>

--- a/apps/web/src/lib/device.ts
+++ b/apps/web/src/lib/device.ts
@@ -1,0 +1,21 @@
+// Mobile detection for gating the editor (which needs a real pointer + screen).
+// The widget page (/w) is intentionally NOT gated so OBS/embeds keep working.
+
+const MOBILE_UA_RE = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Mobile|Tablet|Silk/i;
+
+/** Pure UA test (exported for unit testing). */
+export function isMobileUA(ua: string): boolean {
+  return MOBILE_UA_RE.test(ua);
+}
+
+/**
+ * Whether the current device should get the desktop-only gate. UA-based, plus a
+ * touch check for iPadOS — which reports a desktop Safari UA but is touch-only.
+ */
+export function isMobileDevice(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent;
+  if (isMobileUA(ua)) return true;
+  if (/Macintosh/.test(ua) && typeof document !== "undefined" && "ontouchend" in document) return true;
+  return false;
+}

--- a/apps/web/src/lib/editor/LeftRail.svelte
+++ b/apps/web/src/lib/editor/LeftRail.svelte
@@ -3,6 +3,8 @@
   import { PRESETS } from "$lib/presets";
   import ConfirmButton from "$lib/ui/ConfirmButton.svelte";
   import SidebarFooter from "$lib/editor/SidebarFooter.svelte";
+  import SetupModal from "$lib/editor/SetupModal.svelte";
+  import { recordWidgetCopy } from "$lib/usage";
 
   interface Props {
     editor: EditorState;
@@ -10,6 +12,7 @@
   let { editor }: Props = $props();
 
   let copied = $state(false);
+  let setupOpen = $state(false);
 
   const origin = typeof window !== "undefined" ? window.location.origin : "";
   // Recomputes whenever the config changes (exportHash reads it).
@@ -23,6 +26,7 @@
     } catch {
       /* ignore */
     }
+    recordWidgetCopy(editor.config.lfmUser ?? "");
   }
 
   function connect() {
@@ -143,19 +147,18 @@
         onclick={copyShare}
         class="flex-1 rounded-md bg-primary px-2 py-1.5 text-xs font-medium text-primary-foreground hover:opacity-90"
       >
-        {copied ? "Copied!" : "Copy widget URL"}
+        {copied ? "Copied!" : "Copy URL"}
       </button>
-      <a
-        href={shareUrl}
-        target="_blank"
-        rel="noopener"
+      <button
+        type="button"
+        onclick={() => (setupOpen = true)}
         class="rounded-md border border-border px-2 py-1.5 text-xs hover:bg-muted"
       >
-        Open ↗
-      </a>
+        Add to stream →
+      </button>
     </div>
     <p class="text-[11px] leading-snug text-muted-foreground">
-      Add this URL as an OBS Browser Source.
+      Use it as a browser source in OBS, Streamlabs, XSplit and more.
     </p>
   </section>
 
@@ -286,7 +289,7 @@
 
   <!-- Sidebar footer -->
   <footer class="font-pixel mt-auto border-t border-border pt-3 text-[11px] leading-relaxed text-muted-foreground">
-    <SidebarFooter />
+    <SidebarFooter lfmUser={editor.config.lfmUser} />
   </footer>
 </div>
 
@@ -358,3 +361,11 @@
     </div>
   </div>
 {/if}
+
+<SetupModal
+  bind:open={setupOpen}
+  url={shareUrl}
+  width={editor.config.layout.w}
+  height={editor.config.layout.h}
+  lfmUser={editor.config.lfmUser}
+/>

--- a/apps/web/src/lib/editor/SetupModal.svelte
+++ b/apps/web/src/lib/editor/SetupModal.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+  import Segmented from "$lib/ui/Segmented.svelte";
+  import { recordWidgetCopy } from "$lib/usage";
+
+  interface Props {
+    open: boolean;
+    url: string;
+    width: number;
+    height: number;
+    lfmUser?: string;
+  }
+  let { open = $bindable(), url, width, height, lfmUser = "" }: Props = $props();
+
+  type Platform = "obs" | "streamlabs" | "xsplit" | "other";
+  let platform = $state<Platform>("obs");
+
+  let copied = $state(false);
+  async function copyUrl() {
+    try {
+      await navigator.clipboard.writeText(url);
+      copied = true;
+      setTimeout(() => (copied = false), 1500);
+    } catch {
+      /* ignore */
+    }
+    recordWidgetCopy(lfmUser);
+  }
+
+  function close() {
+    open = false;
+  }
+
+  // Per-platform steps. {W}/{H} are filled with the live widget size.
+  const GUIDES: Record<Platform, { label: string; steps: string[] }> = {
+    obs: {
+      label: "OBS Studio",
+      steps: [
+        "In the Sources box, click + and choose Browser.",
+        'Name it (e.g. "Now Playing") and click OK.',
+        "Paste your widget URL into the URL field.",
+        "Set Width to {W} and Height to {H}.",
+        "Click OK, then drag it where you want on your scene.",
+      ],
+    },
+    streamlabs: {
+      label: "Streamlabs",
+      steps: [
+        "In Sources, click + and pick Browser Source → Add Source.",
+        "Paste your widget URL into the URL field.",
+        "Set Width {W} and Height {H}.",
+        "Click Done and position it on your scene.",
+      ],
+    },
+    xsplit: {
+      label: "XSplit",
+      steps: [
+        "Click Add Source → Webpage / URL (Web page source).",
+        "Paste your widget URL.",
+        "Resize the source to {W} × {H}.",
+        "Drag it into place on your stage.",
+      ],
+    },
+    other: {
+      label: "Other",
+      steps: [
+        "Any app with a Browser / Web page source works (Lightstream, Twitch Studio, vMix…).",
+        "Add a browser/web source and paste your widget URL.",
+        "Set its size to {W} × {H}.",
+        "The background is transparent, so it overlays your scene cleanly.",
+      ],
+    },
+  };
+
+  const steps = $derived(
+    GUIDES[platform].steps.map((s) => s.replace("{W}", String(width)).replace("{H}", String(height))),
+  );
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+    onclick={close}
+    role="presentation"
+  >
+    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+    <div
+      class="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-lg border border-border bg-card text-card-foreground"
+      onclick={(e) => e.stopPropagation()}
+      role="dialog"
+      aria-modal="true"
+      tabindex="-1"
+    >
+      <div class="flex items-start justify-between gap-3 border-b border-border p-4">
+        <div>
+          <h2 class="text-base font-semibold tracking-tight">Add the widget to your stream</h2>
+          <p class="mt-0.5 text-xs text-muted-foreground">
+            It's a browser source — paste the URL into your streaming software.
+          </p>
+        </div>
+        <button
+          type="button"
+          onclick={close}
+          aria-label="Close"
+          class="rounded-md px-2 py-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div class="flex min-h-0 flex-col gap-4 overflow-y-auto p-4">
+        <!-- The URL + recommended size, always visible -->
+        <div class="flex flex-col gap-2 rounded-md border border-border bg-zinc-900/50 p-3">
+          <div class="font-pixel text-[11px] text-muted-foreground uppercase">Your widget URL</div>
+          <div class="flex gap-2">
+            <input
+              type="text"
+              readonly
+              value={url}
+              onclick={(e) => (e.currentTarget as HTMLInputElement).select()}
+              class="min-w-0 flex-1 rounded-md border border-border bg-zinc-800 px-2 py-1.5 font-mono text-xs"
+            />
+            <button
+              type="button"
+              onclick={copyUrl}
+              class="shrink-0 rounded-md bg-primary px-2.5 py-1.5 text-xs font-medium text-primary-foreground hover:opacity-90"
+            >
+              {copied ? "Copied!" : "Copy"}
+            </button>
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener"
+              class="shrink-0 rounded-md border border-border px-2.5 py-1.5 text-xs hover:bg-muted"
+            >
+              Open ↗
+            </a>
+          </div>
+          <p class="text-[11px] text-muted-foreground">
+            Recommended size: <span class="text-foreground">{width} × {height}</span> px. Keep this URL private —
+            it holds your settings (and your API key, if you set one).
+          </p>
+        </div>
+
+        <!-- Platform picker + steps -->
+        <Segmented
+          bind:value={platform}
+          options={[
+            { value: "obs", label: "OBS" },
+            { value: "streamlabs", label: "Streamlabs" },
+            { value: "xsplit", label: "XSplit" },
+            { value: "other", label: "Other" },
+          ]}
+        />
+
+        <ol class="flex list-decimal flex-col gap-2 pl-5 text-sm">
+          {#each steps as step (step)}
+            <li class="leading-snug">{step}</li>
+          {/each}
+        </ol>
+
+        <p class="text-[11px] text-muted-foreground">
+          Edited your design? Re-copy the URL — it changes whenever your settings do, so update the source to
+          see the new look.
+        </p>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/apps/web/src/lib/editor/SidebarFooter.svelte
+++ b/apps/web/src/lib/editor/SidebarFooter.svelte
@@ -1,11 +1,39 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { serviceStatus } from "$lib/status.svelte";
+  import { submitContact, isValidEmail, type ContactResult } from "$lib/usage";
+
+  interface Props {
+    lfmUser?: string;
+  }
+  let { lfmUser = "" }: Props = $props();
 
   const commit = __APP_COMMIT__;
   const repo = "https://github.com/oyuh/applem-util";
 
   onMount(() => serviceStatus.start());
+
+  // ---- Contact form ----
+  let email = $state("");
+  let sending = $state(false);
+  let result = $state<ContactResult | null>(null);
+  const canSend = $derived(isValidEmail(email) && !sending);
+
+  const resultMsg: Record<ContactResult, string> = {
+    ok: "Thanks! We'll only email about outages.",
+    invalid: "Enter a valid email address.",
+    rate: "Too many tries — give it a few minutes.",
+    error: "Couldn't save — try again later.",
+  };
+
+  async function send() {
+    if (!canSend) return;
+    sending = true;
+    result = null;
+    result = await submitContact(email, lfmUser);
+    sending = false;
+    if (result === "ok") email = "";
+  }
 
   const dotColor = $derived(
     serviceStatus.state === "operational"
@@ -47,6 +75,34 @@
             : "Last.fm …",
   );
 </script>
+
+<!-- Contact: email us so we can warn you about outages (linked to your username). -->
+<section class="mb-3 flex flex-col gap-1.5 border-b border-border pb-3">
+  <div class="font-medium text-foreground/80">Contact</div>
+  <p class="leading-snug opacity-70">Get more info about my services and the uptime of this service!</p>
+  <div class="flex gap-1.5">
+    <input
+      type="email"
+      bind:value={email}
+      onkeydown={(e) => e.key === "Enter" && send()}
+      placeholder="you@email.com"
+      autocomplete="email"
+      spellcheck="false"
+      class="min-w-0 flex-1 rounded-md border border-border bg-zinc-800 px-2 py-1 text-[11px] text-foreground"
+    />
+    <button
+      type="button"
+      onclick={send}
+      disabled={!canSend}
+      class="rounded-md border border-border px-2 py-1 text-[11px] hover:bg-muted disabled:opacity-40"
+    >
+      {sending ? "…" : "Notify me"}
+    </button>
+  </div>
+  {#if result}
+    <p class="text-[11px] {result === 'ok' ? 'text-green-400' : 'text-amber-500'}">{resultMsg[result]}</p>
+  {/if}
+</section>
 
 <div class="flex items-center justify-between">
   <span class="flex items-center gap-1.5">

--- a/apps/web/src/lib/usage.ts
+++ b/apps/web/src/lib/usage.ts
@@ -1,0 +1,139 @@
+// Fire-and-forget usage logging. We record which Last.fm usernames actually open
+// or copy the widget (plus a rough device fingerprint + the current song) so we
+// can see real usage. Strictly best-effort: it never throws and never blocks the
+// UI, and a username is required (anonymous events are skipped).
+
+const ENDPOINT = "/api/log/widget";
+
+let cachedFp: string | null = null;
+
+/**
+ * A lightweight, stable-ish browser fingerprint. NOT for security or precise
+ * identification — just enough to roughly distinguish devices in the log. It's a
+ * hash of a few stable signals, so it stays the same across reloads on a device.
+ */
+export function browserFingerprint(): string {
+  if (cachedFp) return cachedFp;
+  if (typeof navigator === "undefined") return "server";
+
+  const n = navigator as Navigator & { deviceMemory?: number };
+  const screenSig =
+    typeof screen !== "undefined" ? `${screen.width}x${screen.height}x${screen.colorDepth}` : "";
+  const parts = [
+    n.userAgent,
+    n.language,
+    (n.languages ?? []).join(","),
+    n.platform,
+    n.hardwareConcurrency,
+    n.deviceMemory,
+    n.maxTouchPoints,
+    screenSig,
+    Intl.DateTimeFormat().resolvedOptions().timeZone,
+    new Date().getTimezoneOffset(),
+  ].join("|");
+
+  cachedFp = cyrb53(parts);
+  return cachedFp;
+}
+
+export type TrackSnapshot = {
+  name?: string | null;
+  artist?: string | null;
+  album?: string | null;
+  isPlaying?: boolean | null;
+};
+
+function send(event: "open" | "copy", lfmUser: string, track?: TrackSnapshot) {
+  if (typeof window === "undefined") return;
+  const user = (lfmUser ?? "").trim();
+  if (!user) return; // usernames are the whole point
+
+  const payload = JSON.stringify({
+    event,
+    lfmUser: user,
+    fp: browserFingerprint(),
+    isPlaying: track?.isPlaying ?? null,
+    track: track
+      ? { name: track.name ?? null, artist: track.artist ?? null, album: track.album ?? null }
+      : null,
+  });
+
+  try {
+    // sendBeacon survives page lifecycle changes (OBS tabs, navigations) and is
+    // non-blocking; fall back to keepalive fetch where it's unavailable.
+    if (typeof navigator !== "undefined" && navigator.sendBeacon) {
+      navigator.sendBeacon(ENDPOINT, new Blob([payload], { type: "application/json" }));
+    } else {
+      void fetch(ENDPOINT, {
+        method: "POST",
+        body: payload,
+        headers: { "Content-Type": "application/json" },
+        keepalive: true,
+      }).catch(() => {});
+    }
+  } catch {
+    /* ignore — logging must never affect the widget */
+  }
+}
+
+/** Record that a widget was opened (the `/w` page loaded for a username). */
+export function recordWidgetOpen(lfmUser: string, track?: TrackSnapshot) {
+  send("open", lfmUser, track);
+}
+
+/** Record that a widget URL was copied from the editor. */
+export function recordWidgetCopy(lfmUser: string) {
+  send("copy", lfmUser);
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function isValidEmail(email: string): boolean {
+  return EMAIL_RE.test(email.trim());
+}
+
+export type ContactResult = "ok" | "invalid" | "rate" | "error";
+
+/**
+ * Submit a contact email so we can reach the user about outages. Sends the
+ * current Last.fm username + device fingerprint too, so the server can link the
+ * email to their widget. Returns a status the form can show.
+ */
+export async function submitContact(email: string, lfmUser: string): Promise<ContactResult> {
+  if (typeof window === "undefined") return "error";
+  const addr = (email ?? "").trim();
+  if (!isValidEmail(addr)) return "invalid";
+
+  try {
+    const r = await fetch("/api/contact", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: addr,
+        lfmUser: (lfmUser ?? "").trim() || null,
+        fp: browserFingerprint(),
+      }),
+    });
+    if (r.status === 429) return "rate";
+    if (!r.ok) return "error";
+    return "ok";
+  } catch {
+    return "error";
+  }
+}
+
+// cyrb53 — a tiny, fast, dependency-free 53-bit string hash. Good enough to turn
+// the fingerprint signals into a short opaque id; not cryptographic.
+function cyrb53(str: string, seed = 0): string {
+  let h1 = 0xdeadbeef ^ seed;
+  let h2 = 0x41c6ce57 ^ seed;
+  for (let i = 0; i < str.length; i++) {
+    const ch = str.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  const n = 4294967296 * (2097151 & h2) + (h1 >>> 0);
+  return n.toString(36);
+}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -7,6 +7,12 @@
   import { NowPlaying } from "$lib/nowplaying.svelte";
   import { resolveApiKey } from "$lib/lastfm-client";
   import { ensureGoogleFonts } from "$lib/fonts";
+  import { isMobileDevice } from "$lib/device";
+  import MobileGate from "$lib/MobileGate.svelte";
+
+  // The editor needs a pointer + a wide screen — gate mobile to a simple page.
+  // (The /w widget route is a separate page and stays usable everywhere.)
+  const mobile = isMobileDevice();
 
   const editor = new EditorState();
   const np = new NowPlaying();
@@ -20,6 +26,7 @@
     );
 
   onMount(() => {
+    if (mobile) return; // no editor on mobile
     editor.load();
     editor.loadPresets();
     editor.initHistory();
@@ -71,17 +78,20 @@
 
   // Live preview from the configured user (falls back to the sample below).
   $effect(() => {
+    if (mobile) return;
     np.setSource(editor.config.lfmUser ?? "", editor.config.sessionKey ?? null, resolveApiKey(editor.config.apiKey));
   });
 
   // Keep Google Fonts in sync with the design.
   $effect(() => {
+    if (mobile) return;
     ensureGoogleFonts(editor.config);
   });
 
   // Autosave to localStorage (debounced).
   let saveTimer: ReturnType<typeof setTimeout>;
   $effect(() => {
+    if (mobile) return;
     JSON.stringify(editor.config); // establish a deep dependency
     editor.dirty = true; // enable undo immediately; cleared when the commit settles
     clearTimeout(saveTimer);
@@ -109,30 +119,34 @@
 </script>
 
 <svelte:head>
-  <title>Music Widget — Editor</title>
+  <title>Last.fm Music Widget</title>
 </svelte:head>
 
-<div class="font-mono-ui grid h-screen grid-cols-[260px_1fr_320px] overflow-hidden bg-background text-foreground">
-  <aside class="min-h-0 border-r border-border bg-sidebar">
-    <LeftRail {editor} />
-  </aside>
+{#if mobile}
+  <MobileGate />
+{:else}
+  <div class="font-mono-ui grid h-screen grid-cols-[260px_1fr_320px] overflow-hidden bg-background text-foreground">
+    <aside class="min-h-0 border-r border-border bg-sidebar">
+      <LeftRail {editor} />
+    </aside>
 
-  <main class="min-h-0 overflow-hidden">
-    <Canvas
-      {editor}
-      isLive={hasLive ? np.isLive : true}
-      isPaused={hasLive ? np.isPaused : false}
-      percent={hasLive ? np.percent : 35}
-      progressMs={hasLive ? np.progressMs : 63000}
-      durationMs={hasLive ? np.durationMs : 180000}
-      title={dTitle}
-      artist={dArtist}
-      album={dAlbum}
-      art={dArt}
-    />
-  </main>
+    <main class="min-h-0 overflow-hidden">
+      <Canvas
+        {editor}
+        isLive={hasLive ? np.isLive : true}
+        isPaused={hasLive ? np.isPaused : false}
+        percent={hasLive ? np.percent : 35}
+        progressMs={hasLive ? np.progressMs : 63000}
+        durationMs={hasLive ? np.durationMs : 180000}
+        title={dTitle}
+        artist={dArtist}
+        album={dAlbum}
+        art={dArt}
+      />
+    </main>
 
-  <aside class="min-h-0 border-l border-border bg-sidebar">
-    <Inspector {editor} />
-  </aside>
-</div>
+    <aside class="min-h-0 border-l border-border bg-sidebar">
+      <Inspector {editor} />
+    </aside>
+  </div>
+{/if}

--- a/apps/web/src/routes/w/+page.svelte
+++ b/apps/web/src/routes/w/+page.svelte
@@ -6,6 +6,7 @@
   import { ensureGoogleFonts } from "$lib/fonts";
   import { NowPlaying } from "$lib/nowplaying.svelte";
   import { resolveApiKey } from "$lib/lastfm-client";
+  import { recordWidgetOpen } from "$lib/usage";
 
   let cfg = $state<WidgetConfig>(defaultConfig);
   const np = new NowPlaying();
@@ -29,6 +30,37 @@
   // Load required Google Fonts.
   $effect(() => {
     ensureGoogleFonts(cfg);
+  });
+
+  // Log this widget open once per page load. Prefer to include the current song,
+  // but don't wait forever — a user who isn't playing anything still counts.
+  let logged = false;
+  $effect(() => {
+    const user = cfg.lfmUser ?? "";
+    if (logged || !user) return;
+
+    const fire = () => {
+      if (logged) return;
+      logged = true;
+      recordWidgetOpen(
+        user,
+        np.track
+          ? {
+              name: np.track.name,
+              artist: np.track.artist?.["#text"],
+              album: np.track.album?.["#text"],
+              isPlaying: np.isLive,
+            }
+          : undefined,
+      );
+    };
+
+    if (np.track) {
+      fire();
+      return;
+    }
+    const t = setTimeout(fire, 4000);
+    return () => clearTimeout(t);
   });
 
   // Transparent page so the widget embeds cleanly as an OBS browser source.

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "music-widget",
       "devDependencies": {
         "concurrently": "^9.1.0",
+        "drizzle-kit": "^0.31.10",
         "typescript": "^6.0.3",
       },
     },
@@ -13,6 +14,7 @@
       "name": "@music-widget/server",
       "version": "0.1.0",
       "dependencies": {
+        "drizzle-orm": "^0.45.2",
         "hono": "^4.6.14",
       },
       "devDependencies": {
@@ -44,6 +46,12 @@
     },
   },
   "packages": {
+    "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
+
+    "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
@@ -236,6 +244,8 @@
 
     "bits-ui": ["bits-ui@1.8.0", "", { "dependencies": { "@floating-ui/core": "^1.6.4", "@floating-ui/dom": "^1.6.7", "@internationalized/date": "^3.5.6", "css.escape": "^1.5.1", "esm-env": "^1.1.2", "runed": "^0.23.2", "svelte-toolbelt": "^0.7.1", "tabbable": "^6.2.0" }, "peerDependencies": { "svelte": "^5.11.0" } }, "sha512-CXD6Orp7l8QevNDcRPLXc/b8iMVgxDWT2LyTwsdLzJKh9CxesOmPuNePSPqAxKoT59FIdU4aFPS1k7eBdbaCxg=="],
 
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -264,6 +274,10 @@
 
     "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
 
+    "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
+
+    "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
+
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.22.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww=="],
@@ -281,6 +295,8 @@
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -346,6 +362,8 @@
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
     "rollup": ["rollup@4.61.0", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.61.0", "@rollup/rollup-android-arm64": "4.61.0", "@rollup/rollup-darwin-arm64": "4.61.0", "@rollup/rollup-darwin-x64": "4.61.0", "@rollup/rollup-freebsd-arm64": "4.61.0", "@rollup/rollup-freebsd-x64": "4.61.0", "@rollup/rollup-linux-arm-gnueabihf": "4.61.0", "@rollup/rollup-linux-arm-musleabihf": "4.61.0", "@rollup/rollup-linux-arm64-gnu": "4.61.0", "@rollup/rollup-linux-arm64-musl": "4.61.0", "@rollup/rollup-linux-loong64-gnu": "4.61.0", "@rollup/rollup-linux-loong64-musl": "4.61.0", "@rollup/rollup-linux-ppc64-gnu": "4.61.0", "@rollup/rollup-linux-ppc64-musl": "4.61.0", "@rollup/rollup-linux-riscv64-gnu": "4.61.0", "@rollup/rollup-linux-riscv64-musl": "4.61.0", "@rollup/rollup-linux-s390x-gnu": "4.61.0", "@rollup/rollup-linux-x64-gnu": "4.61.0", "@rollup/rollup-linux-x64-musl": "4.61.0", "@rollup/rollup-openbsd-x64": "4.61.0", "@rollup/rollup-openharmony-arm64": "4.61.0", "@rollup/rollup-win32-arm64-msvc": "4.61.0", "@rollup/rollup-win32-ia32-msvc": "4.61.0", "@rollup/rollup-win32-x64-gnu": "4.61.0", "@rollup/rollup-win32-x64-msvc": "4.61.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g=="],
 
     "runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
@@ -360,7 +378,11 @@
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -392,6 +414,8 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "tsx": ["tsx@4.22.4", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg=="],
+
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
@@ -412,6 +436,8 @@
 
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
+    "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
     "@music-widget/web/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
@@ -427,5 +453,103 @@
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "tsx/esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.18.20", "", { "os": "android", "cpu": "arm64" }, "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.18.20", "", { "os": "android", "cpu": "x64" }, "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.18.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.18.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.18.20", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.18.20", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.18.20", "", { "os": "linux", "cpu": "arm" }, "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.18.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.18.20", "", { "os": "linux", "cpu": "ia32" }, "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.18.20", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.18.20", "", { "os": "linux", "cpu": "s390x" }, "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.18.20", "", { "os": "linux", "cpu": "x64" }, "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.18.20", "", { "os": "none", "cpu": "x64" }, "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.18.20", "", { "os": "openbsd", "cpu": "x64" }, "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.18.20", "", { "os": "sunos", "cpu": "x64" }, "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.18.20", "", { "os": "win32", "cpu": "arm64" }, "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA=="],
+
+    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.0", "", { "os": "android", "cpu": "arm" }, "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ=="],
+
+    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.0", "", { "os": "android", "cpu": "arm64" }, "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw=="],
+
+    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.0", "", { "os": "android", "cpu": "x64" }, "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA=="],
+
+    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q=="],
+
+    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ=="],
+
+    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q=="],
+
+    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw=="],
+
+    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw=="],
+
+    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A=="],
+
+    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ=="],
+
+    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg=="],
+
+    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w=="],
+
+    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg=="],
+
+    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ=="],
+
+    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q=="],
+
+    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64" }, "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ=="],
+
+    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw=="],
+
+    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.0", "", { "os": "none", "cpu": "x64" }, "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw=="],
+
+    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g=="],
+
+    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA=="],
+
+    "tsx/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w=="],
+
+    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw=="],
+
+    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA=="],
+
+    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA=="],
+
+    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
   }
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,6 @@
-# Local development cache only. The app (Hono + Vite) runs directly on the host
-# via `bun run dev`; this just provides a Redis instance for `bun run dev:server`.
+# Local development backing services. The app (Hono + Vite) runs directly on the
+# host via `bun run dev`; this provides Redis (cache) and Postgres (usage log) for
+# `bun run dev:server`. Data is ephemeral — no volumes are mounted.
 services:
   redis:
     image: redis:7-alpine
@@ -8,6 +9,21 @@ services:
       - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 2s
+      retries: 20
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: applem
+    command: ["postgres", "-c", "fsync=off"] # faster; dev data is disposable
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 2s
       timeout: 2s
       retries: 20

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Architecture
 
-The app is a Bun monorepo deployed as a **single Railway service** plus a Redis
-database.
+The app is a Bun monorepo deployed as a **single Railway service** plus Redis and
+Postgres databases.
 
 ```
 Browser ──────────────► Last.fm API (ws.audioscrobbler.com)   ← direct, CORS
@@ -13,12 +13,18 @@ Railway service (Bun + Hono)            Railway Redis
    • /api/* for signed/private calls     *.railway.internal)
    • image-proxy fallback, sitemap          ▲
    • talks to Redis (Bun.redis) ───────────┘
+   • usage log + contacts (Drizzle ORM) ► Railway Postgres
 ```
 
 ## Packages
 
 - `apps/web` — SvelteKit SPA (`adapter-static`, CSR). The editor (`/`), the
-  standalone widget (`/w`), and the auth callback (`/callback`).
+  standalone widget (`/w`), and the auth callback (`/callback`). The editor is
+  **desktop-only** (`$lib/device.ts` UA check) — on mobile, `/` shows a gate with
+  an email-capture box and source/site links; `/w` stays usable everywhere so
+  embeds and shared links work on any device. The editor's "Add to stream" button
+  opens a setup modal (`$lib/editor/SetupModal.svelte`) with per-platform
+  (OBS/Streamlabs/XSplit) browser-source instructions and the widget URL.
 - `apps/server` — Hono on Bun. Serves the built SPA (`apps/web/build`) and the
   API on one port (`$PORT`).
 
@@ -49,7 +55,34 @@ throttled. Instead:
   calls and as a fallback).
 - `POST /api/lastfm/session` — Last.fm token → session key (signed).
 - `GET /api/proxy-image` — album-art proxy fallback (host-allowlisted).
+- `POST /api/log/widget` — usage log: records a widget open/copy (Last.fm
+  username, device fingerprint, current song, request metadata). Fire-and-forget
+  and **silent** (always 204), fails open when no `DATABASE_URL` is set.
+- `POST /api/contact` — saves a contact email (for outage notifications), linked
+  to a Last.fm username. Has a form UI, so it returns real codes (200 / 400 / 429 / 503).
 - `GET /robots.txt`, `/sitemap.xml`.
+
+## Usage log + contacts (Postgres via Drizzle)
+
+Persistence uses **Drizzle ORM** on Bun's native SQL client
+([`drizzle-orm/bun-sql`](https://orm.drizzle.team)). Schema lives in
+`apps/server/src/schema.ts`; migrations are generated with `bun run db:generate`
+into `apps/server/drizzle/` and **applied automatically on the server's first
+write** (the bun-sql migrator). Like Redis, Postgres is **fail-open**: a missing
+or unreachable DB is logged and ignored, never blocking a request.
+
+- **`widget_events`** — `POST /api/log/widget` fires from the browser when a
+  widget is opened (`/w` loads for a username) or its URL is copied. The server
+  sanitizes the untrusted body (length-capped fields, event coerced to
+  `open`/`copy`), adds IP / user-agent / referer, and **upserts**: a unique index
+  on `(lfm_user, fingerprint, event)` means repeat events from the same device
+  bump `seen_count` / `last_seen_at` and refresh the latest song **instead of
+  duplicating rows**. The route is silent (always 204) and has its own per-IP
+  rate limit (30/min) on top of the global `/api` limiter.
+- **`contacts`** — `POST /api/contact` upserts by email (no duplicates) and links
+  it to a username: the one submitted with the form, or — when absent — recovered
+  from `widget_events` by matching the **same device fingerprint**. So an outage
+  email can name the user's widget. Rate-limited to 5 per 10 min per IP.
 
 ## Caching & resilience (server side)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,6 +22,27 @@ build the SPA → run the server). `railway.json` points at it and uses
 
 In the project: **New → Database → Redis**.
 
+## 2b. Add Postgres (usage log)
+
+In the project: **New → Database → Postgres**. This powers the widget usage log
+(which Last.fm usernames open/copy the overlay, plus device fingerprint, current
+song, metadata) and the contact-email form. It's **optional**: with no
+`DATABASE_URL` set, the endpoints no-op / 503 (fail open). Tables are created via
+**Drizzle migrations applied automatically on the server's first write** — no
+manual migration step. When you change `apps/server/src/schema.ts`, run
+`bun run db:generate` and commit the new file in `apps/server/drizzle/`.
+
+Query it any time from the Railway Postgres console, e.g.:
+
+```sql
+-- most-active widgets (deduped per user+device+event)
+select last_seen_at, event, lfm_user, seen_count, track_name, track_artist
+from widget_events order by last_seen_at desc limit 50;
+
+-- contact emails with their linked Last.fm username (for outage notices)
+select email, lfm_user, updated_at from contacts order by updated_at desc;
+```
+
 ## 3. Set variables on the app service
 
 | Variable | Value | When |
@@ -29,6 +50,7 @@ In the project: **New → Database → Redis**.
 | `LFM_API_KEY` | your Last.fm API key | runtime |
 | `LFM_SHARED_SECRET` | your Last.fm shared secret | runtime (**secret**) |
 | `REDIS_URL` | `${{Redis.REDIS_URL}}` | runtime (private networking) |
+| `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` | runtime (private networking) — enables the usage log |
 | `VITE_LFM_KEY` | the same Last.fm API key (public) | **build** |
 | `VITE_LFM_CALLBACK` | `https://<your-domain>/callback` | **build** |
 
@@ -57,8 +79,14 @@ In your Last.fm API account, set the **Callback URL** to
 
 ```bash
 curl https://<domain>/api/ping       # {"ok":true}
-curl https://<domain>/api/health     # {"ok":true,"redis":"connected"}
+curl https://<domain>/api/health     # {"ok":true,"redis":"connected","db":"connected"}
 curl -i "https://<domain>/api/lastfm/recent?user=rj&limit=1"  # 200 (fallback path)
+curl -i -X POST https://<domain>/api/log/widget \
+  -H 'content-type: application/json' \
+  -d '{"event":"open","lfmUser":"rj","fp":"test"}'            # 204 (silent)
+curl -i -X POST https://<domain>/api/contact \
+  -H 'content-type: application/json' \
+  -d '{"email":"me@example.com","lfmUser":"rj","fp":"test"}'  # {"ok":true}
 ```
 
 Then in a browser: open `/`, set a username, drag things, **Copy widget URL**,

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "drizzle-kit";
+
+// Drizzle Kit config (migration generation). `bun run db:generate` diffs
+// apps/server/src/schema.ts and writes SQL migrations to apps/server/drizzle,
+// which the server applies on startup (see apps/server/src/db.ts).
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./apps/server/src/schema.ts",
+  out: "./apps/server/drizzle",
+  dbCredentials: {
+    url: process.env.DATABASE_URL ?? "postgres://postgres:postgres@localhost:5432/applem",
+  },
+});

--- a/package.json
+++ b/package.json
@@ -12,11 +12,17 @@
     "start": "bun apps/server/src/index.ts",
     "typecheck": "bun run --filter '*' typecheck",
     "test": "bun test",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:studio": "drizzle-kit studio",
     "redis:up": "docker compose -f docker-compose.dev.yml up -d",
-    "redis:down": "docker compose -f docker-compose.dev.yml down"
+    "redis:down": "docker compose -f docker-compose.dev.yml down",
+    "services:up": "docker compose -f docker-compose.dev.yml up -d",
+    "services:down": "docker compose -f docker-compose.dev.yml down"
   },
   "devDependencies": {
     "concurrently": "^9.1.0",
+    "drizzle-kit": "^0.31.10",
     "typescript": "^6.0.3"
   }
 }

--- a/tests/server-analytics.test.ts
+++ b/tests/server-analytics.test.ts
@@ -1,0 +1,62 @@
+import { test, expect, describe } from "bun:test";
+import { buildWidgetEvent } from "../apps/server/src/analytics";
+
+const meta = { ip: "1.2.3.4", userAgent: "UA", referer: "https://apple.jamlog.lol/w" };
+
+describe("buildWidgetEvent", () => {
+  test("maps a full body", () => {
+    const e = buildWidgetEvent(
+      {
+        event: "open",
+        lfmUser: "  rj  ",
+        fp: "abc123",
+        isPlaying: true,
+        track: { name: "Song", artist: "Artist", album: "Album" },
+      },
+      meta,
+    );
+    expect(e).toEqual({
+      event: "open",
+      lfmUser: "rj",
+      fingerprint: "abc123",
+      trackName: "Song",
+      trackArtist: "Artist",
+      trackAlbum: "Album",
+      isPlaying: true,
+      ip: "1.2.3.4",
+      userAgent: "UA",
+      referer: "https://apple.jamlog.lol/w",
+    });
+  });
+
+  test("defaults unknown events to open and only allows open/copy", () => {
+    expect(buildWidgetEvent({ event: "copy", lfmUser: "x" }, meta).event).toBe("copy");
+    expect(buildWidgetEvent({ event: "nonsense", lfmUser: "x" }, meta).event).toBe("open");
+    expect(buildWidgetEvent({ lfmUser: "x" }, meta).event).toBe("open");
+  });
+
+  test("blank / non-string fields become empty user / null meta", () => {
+    const e = buildWidgetEvent({ lfmUser: "   ", fp: 42, track: { name: "" } }, { ip: null, userAgent: null, referer: null });
+    expect(e.lfmUser).toBe(""); // anonymous — the route drops these before storing
+    expect(e.fingerprint).toBeNull();
+    expect(e.trackName).toBeNull();
+    expect(e.ip).toBeNull();
+  });
+
+  test("caps overly long strings", () => {
+    const e = buildWidgetEvent({ lfmUser: "u".repeat(500), track: { name: "n".repeat(1000) } }, meta);
+    expect(e.lfmUser!.length).toBe(64);
+    expect(e.trackName!.length).toBe(256);
+  });
+
+  test("isPlaying falls back to the track flag and tolerates missing values", () => {
+    expect(buildWidgetEvent({ lfmUser: "x", track: { isPlaying: true } }, meta).isPlaying).toBe(true);
+    expect(buildWidgetEvent({ lfmUser: "x" }, meta).isPlaying).toBeNull();
+  });
+
+  test("tolerates a null / non-object body", () => {
+    const e = buildWidgetEvent(null, meta);
+    expect(e.event).toBe("open");
+    expect(e.lfmUser).toBe("");
+  });
+});

--- a/tests/web-device.test.ts
+++ b/tests/web-device.test.ts
@@ -1,0 +1,24 @@
+import { test, expect, describe } from "bun:test";
+import { isMobileUA } from "../apps/web/src/lib/device";
+
+const MOBILE = [
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148",
+  "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Mobile Safari/537.36",
+  "Mozilla/5.0 (iPad; CPU OS 16_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148",
+];
+
+const DESKTOP = [
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/146 Safari/537.36",
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Safari/605.1.15",
+  // OBS / browser-source UAs look like desktop Chrome — must NOT be gated.
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120 Safari/537.36 OBS/30",
+];
+
+describe("isMobileUA", () => {
+  test("flags phones and tablets", () => {
+    for (const ua of MOBILE) expect(isMobileUA(ua)).toBe(true);
+  });
+  test("leaves desktop / OBS alone", () => {
+    for (const ua of DESKTOP) expect(isMobileUA(ua)).toBe(false);
+  });
+});

--- a/tests/web-usage.test.ts
+++ b/tests/web-usage.test.ts
@@ -1,0 +1,16 @@
+import { test, expect, describe } from "bun:test";
+import { isValidEmail } from "../apps/web/src/lib/usage";
+
+describe("isValidEmail", () => {
+  test("accepts normal addresses", () => {
+    for (const e of ["a@b.co", "first.last@example.com", "  spaced@trim.io  "]) {
+      expect(isValidEmail(e)).toBe(true);
+    }
+  });
+
+  test("rejects junk", () => {
+    for (const e of ["", "nope", "a@b", "a@@b.com", "a b@c.com", "@x.com", "x@.com"]) {
+      expect(isValidEmail(e)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## What & why

Adds an opt-in analytics + contact layer (Postgres via **Drizzle ORM**) plus two editor UX features. All persistence is **fail-open**: with no `DATABASE_URL` the endpoints no-op, and an unreachable/slow DB never blocks serving the widget.

### Usage logging
- `POST /api/log/widget` records widget **opens** (the `/w` page loading for a username) and **copies** (editor "Copy URL" + setup-modal copy). Sent **silently** via `sendBeacon` so opening/copying is never blocked.
- Server **sanitizes** the untrusted body (length-capped fields, event coerced to `open`/`copy`), adds IP/user-agent/referer, and **upserts**: a unique index on `(lfm_user, fingerprint, event)` collapses repeats into one row that bumps `seen_count` and refreshes the latest song — **no duplicate rows**. Dedicated per-IP rate limit (30/min) on top of the global `/api` limiter.

### Contacts + linking
- A "Contact" form in the sidebar footer (and on the mobile gate) `POST`s to `/api/contact`, which upserts by email (no dupes, validated, rate-limited 5/10min) and **links the email to a Last.fm username** — the one supplied, or recovered from `widget_events` by matching the same device fingerprint. So an outage email can name the user's widget.

### Mobile gate (desktop-only)
- The editor (`/`) needs a pointer + wide screen, so a UA check (`device.ts`) shows a gate on mobile with an email box + view-source / personal-site links. **`/w` is intentionally NOT gated** so embeds and shared links work on any device.

### Setup modal
- The editor's **"Add to stream"** button opens a modal with the widget URL (copy/open), live recommended size, and per-platform browser-source steps (OBS / Streamlabs / XSplit / Other).

## Infra
- Drizzle schema in `apps/server/src/schema.ts`; migrations generated to `apps/server/drizzle` and **applied automatically on the server's first write** (bun-sql migrator), self-healing if the schema goes missing (e.g. a DB redeploy).
- Local dev: Postgres added to `docker-compose.dev.yml` with a `services:up` script. `db:generate` / `db:migrate` scripts added.

## Reviewer notes
- **Railway**: add a Postgres plugin and set `DATABASE_URL=${{Postgres.DATABASE_URL}}`. Until then everything no-ops (fail-open). See `docs/deployment.md`.
- New deps: `drizzle-orm` (server runtime), `drizzle-kit` (root dev).
- **Privacy**: stores IP + device fingerprint + user-agent alongside usernames/emails.

## Testing
- 46 unit tests pass (`buildWidgetEvent` sanitization, `isMobileUA`, `isValidEmail`); server + web typecheck clean.
- Verified end-to-end against a real Postgres: dedup (`seen_count` bumps, one row), contact upsert + fingerprint linking, silent log route, rate limiting (`429`), the setup modal (tabs/copy), and the mobile gate rendering + email submit (with `/w` still usable under a mobile UA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)